### PR TITLE
Tower Upgrade, Garium, Slight Enemy Improvement

### DIFF
--- a/New Solar Revolt/Assets/Prefabs/Enemy.prefab
+++ b/New Solar Revolt/Assets/Prefabs/Enemy.prefab
@@ -164,4 +164,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 646e4915ebf49b34a8bac95d143713ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  health: 20
+  enemyGarium: 10
+  enemyHealth: 3

--- a/New Solar Revolt/Assets/Prefabs/Projectile A.prefab
+++ b/New Solar Revolt/Assets/Prefabs/Projectile A.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 7821294292035860848}
   m_Layer: 0
   m_Name: Projectile A
-  m_TagString: Untagged
+  m_TagString: Projectile
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/New Solar Revolt/Assets/Prefabs/Turret Av1.prefab
+++ b/New Solar Revolt/Assets/Prefabs/Turret Av1.prefab
@@ -94,9 +94,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1508908102647878147}
-  - component: {fileID: 1508908102647878146}
   - component: {fileID: 5773510720556010307}
+  - component: {fileID: 1101780684377462538}
   - component: {fileID: 2037778476}
+  - component: {fileID: 1508908102647878146}
+  - component: {fileID: 5308531968157841055}
   m_Layer: 0
   m_Name: Turret Av1
   m_TagString: Tower
@@ -118,26 +120,10 @@ Transform:
   m_Children:
   - {fileID: 1508908103272588389}
   - {fileID: 1508908102099296520}
+  - {fileID: 1019991353081689778}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1508908102647878146
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1508908102647878157}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ba4619e75049fe9449a0142629c35786, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  directionObject: {fileID: 1508908102099296520}
-  fireRate: 1
-  pfBulletA: {fileID: 200645615588126804, guid: d5ec39336ea241546aee2e3c29090d5f, type: 3}
-  spawnLocationBulletA: {fileID: 529831527767011737}
-  targetPriority: 71
 --- !u!58 &5773510720556010307
 CircleCollider2D:
   m_ObjectHideFlags: 0
@@ -154,6 +140,32 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 10
+--- !u!61 &1101780684377462538
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1508908102647878157}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 3, y: 3}
+  m_EdgeRadius: 0
 --- !u!50 &2037778476
 Rigidbody2D:
   serializedVersion: 4
@@ -175,6 +187,37 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
+--- !u!114 &1508908102647878146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1508908102647878157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba4619e75049fe9449a0142629c35786, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  directionObject: {fileID: 1508908102099296520}
+  fireRate: 1
+  pfBulletA: {fileID: 200645615588126804, guid: d5ec39336ea241546aee2e3c29090d5f, type: 3}
+  spawnLocationBulletA: {fileID: 529831527767011737}
+  enemiesInRange: []
+  targetPriority: 71
+--- !u!114 &5308531968157841055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1508908102647878157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 47f1cf709c5cb154cb1f535402b181ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  towerOptions: {fileID: 6122865469739058852}
 --- !u!1 &1508908103272588388
 GameObject:
   m_ObjectHideFlags: 0
@@ -259,6 +302,241 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &5210449643392904223
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4522361160219556834}
+  - component: {fileID: 8499615053411907118}
+  - component: {fileID: 8282047442061067647}
+  m_Layer: 0
+  m_Name: Sell
+  m_TagString: Sell
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4522361160219556834
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5210449643392904223}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3, y: 3, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1019991353081689778}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8499615053411907118
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5210449643392904223}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.8584906, g: 0.29102853, b: 0.18951581, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &8282047442061067647
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5210449643392904223}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!1 &5818828991540344569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6516740641733157388}
+  - component: {fileID: 8529621904163408802}
+  - component: {fileID: 460549452511555907}
+  m_Layer: 0
+  m_Name: Upgrade
+  m_TagString: Upgrade
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6516740641733157388
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5818828991540344569}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3, y: 3, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1019991353081689778}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8529621904163408802
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5818828991540344569}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.16703449, g: 0.8679245, b: 0.22598787, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &460549452511555907
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5818828991540344569}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!1 &6122865469739058852
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1019991353081689778}
+  m_Layer: 0
+  m_Name: TowerOptions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1019991353081689778
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6122865469739058852}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6516740641733157388}
+  - {fileID: 4522361160219556834}
+  m_Father: {fileID: 1508908102647878147}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6677190231570349743
 GameObject:
   m_ObjectHideFlags: 0

--- a/New Solar Revolt/Assets/Scenes/Level1Prototype.unity
+++ b/New Solar Revolt/Assets/Scenes/Level1Prototype.unity
@@ -6457,6 +6457,7 @@ GameObject:
   - component: {fileID: 519437008}
   - component: {fileID: 519437009}
   - component: {fileID: 519437010}
+  - component: {fileID: 519437011}
   m_Layer: 0
   m_Name: Game Manager
   m_TagString: Untagged
@@ -6508,6 +6509,19 @@ MonoBehaviour:
   totalWaves: 3
   spawnPoint: {fileID: 65039514}
   countdown: 2
+--- !u!114 &519437011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519437007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56829015daf077a4b9221b9c316ce2d4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  camera: {fileID: 519420031}
 --- !u!1001 &525306198
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/New Solar Revolt/Assets/Scenes/Level1Prototype.unity
+++ b/New Solar Revolt/Assets/Scenes/Level1Prototype.unity
@@ -6458,6 +6458,7 @@ GameObject:
   - component: {fileID: 519437009}
   - component: {fileID: 519437010}
   - component: {fileID: 519437011}
+  - component: {fileID: 519437012}
   m_Layer: 0
   m_Name: Game Manager
   m_TagString: Untagged
@@ -6522,6 +6523,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   camera: {fileID: 519420031}
+--- !u!114 &519437012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519437007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f70b7d6529d55314ba32f0f68c73c627, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &525306198
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/New Solar Revolt/Assets/Scripts/BulletAScript.cs
+++ b/New Solar Revolt/Assets/Scripts/BulletAScript.cs
@@ -32,6 +32,7 @@ public class BulletAScript : MonoBehaviour
         {
             if (collision.gameObject.Equals(target))
             {
+                target.GetComponent<EnemyAttributesScript>().EnemyHealth--; //replace with tower damage (Wood's Code Needed)
                 Destroy(gameObject);
             }
             else

--- a/New Solar Revolt/Assets/Scripts/BulletAScript.cs
+++ b/New Solar Revolt/Assets/Scripts/BulletAScript.cs
@@ -18,6 +18,10 @@ public class BulletAScript : MonoBehaviour
 
     void Update()
     {
+        if(target == null)
+        {
+            Destroy(gameObject);
+        }
         TravelToTarget();
         CheckOutOfBounds();
     }

--- a/New Solar Revolt/Assets/Scripts/EnemyAttributesScript.cs
+++ b/New Solar Revolt/Assets/Scripts/EnemyAttributesScript.cs
@@ -4,11 +4,35 @@ using UnityEngine;
 
 public class EnemyAttributesScript : MonoBehaviour
 {
-    public int health;
+    //Values are serialized so one script can be applied to 3 different enemies
+    //SeralizedField makes you input values in the inspector
+    [SerializeField] private int enemyGarium;
+    [SerializeField] private int enemyHealth;
 
-    private void Start()
+
+    private void Update()
     {
-        //health = 10;
+        IncreasePlayerGarium();
     }
 
+    public int EnemyGarium
+    {
+        get { return enemyGarium; }
+        set { enemyGarium = value; }
+    }
+
+    public int EnemyHealth
+    {
+        get { return enemyHealth; }
+        set { enemyHealth = value; }
+    }
+
+    private void IncreasePlayerGarium()
+    {
+        if (enemyHealth < 1)
+        {
+            Destroy(gameObject);
+            GariumScript.Garium += enemyGarium;
+        }
+    }
 }

--- a/New Solar Revolt/Assets/Scripts/GariumScript.cs
+++ b/New Solar Revolt/Assets/Scripts/GariumScript.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GariumScript : MonoBehaviour
+{
+    [SerializeField] private static int garium;
+    void Start()
+    {
+        garium = 0;
+    }
+
+    
+    void Update()
+    {
+
+    }
+
+    public static int Garium
+    {
+        get { return garium; }  //read
+        set { garium = value; } //write
+    }
+}

--- a/New Solar Revolt/Assets/Scripts/GariumScript.cs
+++ b/New Solar Revolt/Assets/Scripts/GariumScript.cs
@@ -5,20 +5,43 @@ using UnityEngine;
 public class GariumScript : MonoBehaviour
 {
     [SerializeField] private static int garium;
+    private float second;
+
     void Start()
     {
         garium = 0;
+        second = 0;
     }
 
     
     void Update()
     {
-
+        second += Time.deltaTime;
+        IncrementGarium();
+        ValueProofGarium();
     }
 
     public static int Garium
     {
-        get { return garium; }  //read
-        set { garium = value; } //write
+        get { return garium; }
+        set { garium = value; }
+    }
+
+    private void IncrementGarium()
+    {
+        if (second > 0.5)
+        {
+            garium++;
+            second = 0;
+        }
+        
+    }
+
+    private void ValueProofGarium()
+    {
+        if(garium < 0)
+        {
+            garium = 0;
+        }
     }
 }

--- a/New Solar Revolt/Assets/Scripts/GariumScript.cs.meta
+++ b/New Solar Revolt/Assets/Scripts/GariumScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f70b7d6529d55314ba32f0f68c73c627
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Solar Revolt/Assets/Scripts/MouseRayCastScript.cs
+++ b/New Solar Revolt/Assets/Scripts/MouseRayCastScript.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MouseRayCastScript : MonoBehaviour
+{
+    [SerializeField] private Camera camera;
+
+    public static RaycastHit2D[] rc;
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        Vector2 origin = new Vector2(camera.ScreenToWorldPoint(Input.mousePosition).x, camera.ScreenToWorldPoint(Input.mousePosition).y);
+        rc = Physics2D.RaycastAll(origin, Vector2.zero, 0f);
+    }
+}

--- a/New Solar Revolt/Assets/Scripts/MouseRayCastScript.cs.meta
+++ b/New Solar Revolt/Assets/Scripts/MouseRayCastScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56829015daf077a4b9221b9c316ce2d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Solar Revolt/Assets/Scripts/TowerOptionsScript.cs
+++ b/New Solar Revolt/Assets/Scripts/TowerOptionsScript.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine.EventSystems;
+using UnityEngine;
+
+public class TowerOptionsScript : MonoBehaviour
+{
+    [SerializeField] private GameObject towerOptions;
+    private RaycastHit2D[] rc;
+    private GameObject selectedTower;
+
+    private void OnMouseUpAsButton()
+    {
+        rc = MouseRayCastScript.rc;
+        if (rc.Length > 1)
+        {
+            Debug.Log(rc.Length);
+            for (int i = 0; i < rc.Length; i++)
+            {
+                if (rc[i].collider is BoxCollider2D && rc[i].transform.CompareTag("Tower"))
+                {
+                    if(rc[i].collider.transform.root.gameObject == transform.gameObject)
+                    {
+                        Debug.Log("RIGHT PARENT");
+                        towerOptions.SetActive(!towerOptions.activeSelf);
+                        selectedTower = towerOptions.transform.root.gameObject;
+                        Debug.Log(selectedTower.name);
+                    }
+                    
+                }
+
+                if (rc[i].collider.transform.CompareTag("Upgrade"))
+                {
+                    Debug.Log("UPGRAADE");
+                    CircleCollider2D towerRadius = rc[i].collider.transform.root.GetComponent<CircleCollider2D>();
+                    towerRadius.radius += 5;
+                    GariumScript.Garium -= 5;
+                    //add damage
+                    //increase firerate(?)
+                    //decrease garium
+                }
+                else if (rc[i].collider.transform.CompareTag("Sell")){
+                    Debug.Log("SELLL");
+                    
+                    //Destroy Object and add GARIUUUUM
+                }
+            }
+        }
+
+    }
+
+    
+    
+}

--- a/New Solar Revolt/Assets/Scripts/TowerOptionsScript.cs
+++ b/New Solar Revolt/Assets/Scripts/TowerOptionsScript.cs
@@ -29,27 +29,40 @@ public class TowerOptionsScript : MonoBehaviour
                         }
                     }                    
                 }
-
+                
                 if (rc[i].collider.transform.CompareTag("Upgrade"))
                 {
-                    Debug.Log("UPGRAADE");
-                    CircleCollider2D towerRadius = rc[i].collider.transform.root.GetComponent<CircleCollider2D>();
-                    towerRadius.radius += 5;
-                    GariumScript.Garium -= 5;
-                    //add damage
-                    //increase firerate(?)
-                    //decrease garium
+                    UpgradeTower(rc[i]);
                 }
-                else if (rc[i].collider.transform.CompareTag("Sell")){
-                    Debug.Log("SELLL");
-                    
-                    //Destroy Object and add GARIUUUUM
+                else if (rc[i].collider.transform.CompareTag("Sell"))
+                {
+                    SellTower(rc[i]);
                 }
             }
         }
-
     }
 
-    
-    
+    private void UpgradeTower(RaycastHit2D rc)
+    {
+        CircleCollider2D towerRadius = rc.collider.transform.root.GetComponent<CircleCollider2D>();
+        int gariumCost = towerRadius.transform.GetComponent<TurretAScript>().GariumCost;
+        if (GariumScript.Garium < gariumCost) { return; }
+
+        towerRadius.radius += 5;
+        GariumScript.Garium -= gariumCost;
+        towerRadius.transform.GetComponent<TurretAScript>().GariumCost += 30;
+
+        //add damage (need Wood's Code)
+        //increase firerate(?)
+    }
+
+    private void SellTower(RaycastHit2D rc)
+    {
+        CircleCollider2D towerRadius = rc.collider.transform.root.GetComponent<CircleCollider2D>();
+        GariumScript.Garium += (towerRadius.transform.GetComponent<TurretAScript>().GariumCost / 3);
+        Destroy(gameObject);
+    }
+
+
+
 }

--- a/New Solar Revolt/Assets/Scripts/TowerOptionsScript.cs
+++ b/New Solar Revolt/Assets/Scripts/TowerOptionsScript.cs
@@ -5,28 +5,29 @@ using UnityEngine;
 
 public class TowerOptionsScript : MonoBehaviour
 {
-    [SerializeField] private GameObject towerOptions;
     private RaycastHit2D[] rc;
-    private GameObject selectedTower;
 
     private void OnMouseUpAsButton()
     {
         rc = MouseRayCastScript.rc;
         if (rc.Length > 1)
         {
-            Debug.Log(rc.Length);
             for (int i = 0; i < rc.Length; i++)
             {
                 if (rc[i].collider is BoxCollider2D && rc[i].transform.CompareTag("Tower"))
                 {
-                    if(rc[i].collider.transform.root.gameObject == transform.gameObject)
+                    Transform boxColliderTransform = rc[i].collider.transform;
+                    //Traverse from the parent to the needed child object
+                    for(int j = 0; j < boxColliderTransform.childCount; j++)
                     {
-                        Debug.Log("RIGHT PARENT");
-                        towerOptions.SetActive(!towerOptions.activeSelf);
-                        selectedTower = towerOptions.transform.root.gameObject;
-                        Debug.Log(selectedTower.name);
-                    }
-                    
+                        //Ensures that tower under mouse will be interacted and not some other tower 
+                        //whose collider overlaps with the tower
+                        if(boxColliderTransform.GetChild(j).name.Equals("TowerOptions"))
+                        {
+                            Transform towerOptionsTransform = boxColliderTransform.GetChild(j);
+                            towerOptionsTransform.gameObject.SetActive(!towerOptionsTransform.gameObject.activeSelf);
+                        }
+                    }                    
                 }
 
                 if (rc[i].collider.transform.CompareTag("Upgrade"))

--- a/New Solar Revolt/Assets/Scripts/TowerOptionsScript.cs.meta
+++ b/New Solar Revolt/Assets/Scripts/TowerOptionsScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47f1cf709c5cb154cb1f535402b181ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Solar Revolt/Assets/Scripts/TurretAScript.cs
+++ b/New Solar Revolt/Assets/Scripts/TurretAScript.cs
@@ -4,14 +4,15 @@ using UnityEngine;
 
 public class TurretAScript : MonoBehaviour
 {
+    [SerializeField] private int gariumCost;
     private Transform target;  
 
     //For direction;
     public Transform directionObject;
 
     //Bullet-related
-    public float fireRate = 1f;
-    private float fireCountdown = 0f;
+    public float fireRate;
+    private float fireCountdown;
 
     //Bullet Prefabs-related
     public GameObject pfBulletA;
@@ -26,6 +27,9 @@ public class TurretAScript : MonoBehaviour
     {
         //InvokeRepeating("TargetEnemyNearGoal", 0f, 1f);
         targetPriority = 'G';
+        fireRate = 1f;
+        fireCountdown = 0f;
+        gariumCost = 20;
     }
 
     private void Update()
@@ -46,6 +50,12 @@ public class TurretAScript : MonoBehaviour
         }
         fireCountdown -= Time.deltaTime;
 
+    }
+
+    public int GariumCost
+    {
+        get { return gariumCost; }
+        set { gariumCost = value; }
     }
 
     private void OnTriggerEnter2D(Collider2D collision)
@@ -162,7 +172,7 @@ public class TurretAScript : MonoBehaviour
         int maxHealth = -10000;
         foreach (GameObject enemy in enemiesInRange)
         {
-            int currEnemyHealth = enemy.GetComponent<EnemyAttributesScript>().health;
+            int currEnemyHealth = enemy.GetComponent<EnemyAttributesScript>().EnemyHealth;
             if (currEnemyHealth > maxHealth)
             {
                 target = enemy.transform;
@@ -188,7 +198,7 @@ public class TurretAScript : MonoBehaviour
         int minHealth = 10000;
         foreach (GameObject enemy in enemiesInRange)
         {
-            int currEnemyHealth = enemy.GetComponent<EnemyAttributesScript>().health;
+            int currEnemyHealth = enemy.GetComponent<EnemyAttributesScript>().EnemyHealth;
             if (currEnemyHealth < minHealth)
             {
                 target = enemy.transform;

--- a/New Solar Revolt/ProjectSettings/TagManager.asset
+++ b/New Solar Revolt/ProjectSettings/TagManager.asset
@@ -8,6 +8,7 @@ TagManager:
   - Tower
   - Upgrade
   - Sell
+  - Projectile
   layers:
   - Default
   - TransparentFX

--- a/New Solar Revolt/ProjectSettings/TagManager.asset
+++ b/New Solar Revolt/ProjectSettings/TagManager.asset
@@ -6,6 +6,8 @@ TagManager:
   tags:
   - Enemy
   - Tower
+  - Upgrade
+  - Sell
   layers:
   - Default
   - TransparentFX

--- a/New Solar Revolt/UserSettings/Layouts/default-2021.dwlt
+++ b/New Solar Revolt/UserSettings/Layouts/default-2021.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 1536
     height: 780.8
   m_ShowMode: 4
-  m_Title: Game
+  m_Title: Hierarchy
   m_RootView: {fileID: 6}
   m_MinSize: {x: 875, y: 371}
   m_MaxSize: {x: 10000, y: 10000}
@@ -48,7 +48,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 96
+  controlID: 23
 --- !u!114 &3
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -64,9 +64,9 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 1173.6
+    x: 1167.2
     y: 0
-    width: 362.40002
+    width: 368.80005
     height: 730.8
   m_MinSize: {x: 276, y: 71}
   m_MaxSize: {x: 4001, y: 4021}
@@ -92,7 +92,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 253.6
+    width: 249.6
     height: 474.4
   m_MinSize: {x: 201, y: 221}
   m_MaxSize: {x: 4001, y: 4021}
@@ -111,23 +111,23 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ProjectBrowser
+  m_Name: ConsoleWindow
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
     serializedVersion: 2
     x: 0
     y: 474.4
-    width: 1173.6
+    width: 1167.2
     height: 256.4
-  m_MinSize: {x: 231, y: 271}
-  m_MaxSize: {x: 10001, y: 10021}
-  m_ActualView: {fileID: 12}
+  m_MinSize: {x: 101, y: 121}
+  m_MaxSize: {x: 4001, y: 4021}
+  m_ActualView: {fileID: 17}
   m_Panes:
   - {fileID: 12}
   - {fileID: 17}
-  m_Selected: 0
-  m_LastSelected: 1
+  m_Selected: 1
+  m_LastSelected: 0
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -218,12 +218,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1173.6
+    width: 1167.2
     height: 730.8
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 84
+  controlID: 96
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -243,12 +243,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1173.6
+    width: 1167.2
     height: 474.4
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 85
+  controlID: 97
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -259,23 +259,23 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: SceneView
+  m_Name: GameView
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 253.6
+    x: 249.6
     y: 0
-    width: 920
+    width: 917.6
     height: 474.4
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
-  m_ActualView: {fileID: 15}
+  m_ActualView: {fileID: 16}
   m_Panes:
   - {fileID: 15}
   - {fileID: 16}
-  m_Selected: 0
-  m_LastSelected: 1
+  m_Selected: 1
+  m_LastSelected: 0
 --- !u!114 &12
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -298,7 +298,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 548
-    width: 1172.6
+    width: 1166.2
     height: 235.4
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -331,9 +331,9 @@ MonoBehaviour:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: e0650000
-    m_LastClickedID: 26080
-    m_ExpandedIDs: 00000000d465000000ca9a3b
+    m_SelectedIDs: 24660000
+    m_LastClickedID: 26148
+    m_ExpandedIDs: 000000001866000000ca9a3b
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -361,7 +361,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000d4650000
+    m_ExpandedIDs: 0000000018660000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -386,24 +386,24 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: 
-    m_LastClickedInstanceID: 0
+    m_SelectedInstanceIDs: 68f5ffff
+    m_LastClickedInstanceID: -2712
     m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
-      m_Name: TowerTargetPriorityScript
-      m_OriginalName: TowerTargetPriorityScript
+      m_Name: 
+      m_OriginalName: 
       m_EditFieldRect:
         serializedVersion: 2
         x: 0
         y: 0
         width: 0
         height: 0
-      m_UserData: 32008
+      m_UserData: 0
       m_IsWaitingForDelay: 0
       m_IsRenaming: 0
-      m_OriginalEventType: 0
+      m_OriginalEventType: 11
       m_IsRenamingFilename: 1
       m_ClientGUIView: {fileID: 5}
     m_CreateAssetUtility:
@@ -437,9 +437,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1173.6
+    x: 1167.2001
     y: 73.6
-    width: 361.40002
+    width: 367.80005
     height: 709.8
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -480,7 +480,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 73.6
-    width: 252.6
+    width: 248.6
     height: 453.4
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -489,25 +489,25 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 92afffff
-      m_LastClickedID: -20590
-      m_ExpandedIDs: bae2ffff70e8ffff78eeffff2ef4ffff2afbffff
+      m_SelectedIDs: a8f8ffff
+      m_LastClickedID: -1880
+      m_ExpandedIDs: a8f8ffff2afbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
-        m_Name: Enemy(Clone)
-        m_OriginalName: Enemy(Clone)
+        m_Name: 
+        m_OriginalName: 
         m_EditFieldRect:
           serializedVersion: 2
           x: 0
           y: 0
           width: 0
           height: 0
-        m_UserData: -20634
+        m_UserData: 0
         m_IsWaitingForDelay: 0
         m_IsRenaming: 0
-        m_OriginalEventType: 0
+        m_OriginalEventType: 11
         m_IsRenamingFilename: 0
-        m_ClientGUIView: {fileID: 4}
+        m_ClientGUIView: {fileID: 5}
       m_SearchString: 
     m_ExpandedScenes: []
     m_CurrenRootInstanceID: 0
@@ -535,9 +535,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 253.6
+    x: 249.6
     y: 73.6
-    width: 918
+    width: 915.6
     height: 453.4
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -614,7 +614,7 @@ MonoBehaviour:
       floating: 0
       collapsed: 0
       displayed: 1
-      snapOffset: {x: 0, y: 24.8}
+      snapOffset: {x: 0, y: 0}
       snapOffsetDelta: {x: 0, y: 0}
       snapCorner: 0
       id: unity-transform-toolbar
@@ -762,9 +762,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: 7.0790925, y: -5.6714916, z: -0.3181889}
+    m_Target: {x: 5.265153, y: -7.173116, z: -0.25197923}
     speed: 2
-    m_Value: {x: 7.0790925, y: -5.6714916, z: -0.3181889}
+    m_Value: {x: 5.265153, y: -7.173116, z: -0.25197923}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -815,9 +815,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 32.868717
+    m_Target: 25.780058
     speed: 2
-    m_Value: 32.868717
+    m_Value: 25.780058
   m_Ortho:
     m_Target: 1
     speed: 2
@@ -862,9 +862,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 253.6
+    x: 249.6
     y: 73.6
-    width: 918
+    width: 915.6
     height: 453.4
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -903,7 +903,7 @@ MonoBehaviour:
     m_HSlider: 0
     m_VSlider: 0
     m_IgnoreScrollWheelUntilClicked: 0
-    m_EnableMouseInput: 0
+    m_EnableMouseInput: 1
     m_EnableSliderZoomHorizontal: 0
     m_EnableSliderZoomVertical: 0
     m_UniformScale: 1
@@ -912,23 +912,23 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 918
+      width: 915.6
       height: 432.4
     m_Scale: {x: 1, y: 1}
-    m_Translation: {x: 459, y: 216.2}
+    m_Translation: {x: 457.8, y: 216.2}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -459
+      x: -457.8
       y: -216.2
-      width: 918
+      width: 915.6
       height: 432.4
     m_MinimalGUI: 1
   m_defaultScale: 1
-  m_LastWindowPixelSize: {x: 1147.5, y: 566.75}
+  m_LastWindowPixelSize: {x: 1144.5, y: 566.75}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 01000000000000000000
@@ -956,7 +956,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 548
-    width: 1172.6
+    width: 1166.2
     height: 235.4
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:

--- a/New Solar Revolt/UserSettings/Layouts/default-2021.dwlt
+++ b/New Solar Revolt/UserSettings/Layouts/default-2021.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 1536
     height: 780.8
   m_ShowMode: 4
-  m_Title: Hierarchy
+  m_Title: Game
   m_RootView: {fileID: 6}
   m_MinSize: {x: 875, y: 371}
   m_MaxSize: {x: 10000, y: 10000}
@@ -48,7 +48,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 23
+  controlID: 17
 --- !u!114 &3
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -223,7 +223,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 96
+  controlID: 53
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -248,7 +248,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 97
+  controlID: 54
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -317,13 +317,13 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Prefabs
+    - Assets/Scripts
     m_Globs: []
     m_OriginalText: 
   m_ViewMode: 1
   m_StartGridSize: 16
   m_LastFolders:
-  - Assets/Prefabs
+  - Assets/Scripts
   m_LastFoldersGridSize: 16
   m_LastProjectPath: C:\Users\user\Documents\GitHub\Solar-Revolt-New-Repo\New Solar
     Revolt
@@ -333,7 +333,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 24660000
     m_LastClickedID: 26148
-    m_ExpandedIDs: 000000001866000000ca9a3b
+    m_ExpandedIDs: 000000001266000000ca9a3b
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -361,7 +361,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 0000000018660000
+    m_ExpandedIDs: 0000000012660000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -386,8 +386,8 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: 68f5ffff
-    m_LastClickedInstanceID: -2712
+    m_SelectedInstanceIDs: 940b0000
+    m_LastClickedInstanceID: 2964
     m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:
@@ -413,7 +413,7 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
     m_NewAssetIndexInList: -1
-    m_ScrollPosition: {x: 0, y: 0}
+    m_ScrollPosition: {x: 0, y: 3.600006}
     m_GridSize: 16
   m_SkipHiddenPackages: 0
   m_DirectoriesAreaWidth: 198

--- a/New Solar Revolt/UserSettings/Layouts/default-2021.dwlt
+++ b/New Solar Revolt/UserSettings/Layouts/default-2021.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 1536
     height: 780.8
   m_ShowMode: 4
-  m_Title: Game
+  m_Title: Project
   m_RootView: {fileID: 6}
   m_MinSize: {x: 875, y: 371}
   m_MaxSize: {x: 10000, y: 10000}
@@ -111,7 +111,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ConsoleWindow
+  m_Name: ProjectBrowser
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
@@ -120,14 +120,14 @@ MonoBehaviour:
     y: 474.4
     width: 1167.2
     height: 256.4
-  m_MinSize: {x: 101, y: 121}
-  m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 17}
+  m_MinSize: {x: 231, y: 271}
+  m_MaxSize: {x: 10001, y: 10021}
+  m_ActualView: {fileID: 12}
   m_Panes:
   - {fileID: 12}
   - {fileID: 17}
-  m_Selected: 1
-  m_LastSelected: 0
+  m_Selected: 0
+  m_LastSelected: 1
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -223,7 +223,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 53
+  controlID: 55
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -248,7 +248,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 54
+  controlID: 56
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -386,24 +386,24 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: 940b0000
-    m_LastClickedInstanceID: 2964
+    m_SelectedInstanceIDs: 
+    m_LastClickedInstanceID: 0
     m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
-      m_Name: 
-      m_OriginalName: 
+      m_Name: Prefabs
+      m_OriginalName: Prefabs
       m_EditFieldRect:
         serializedVersion: 2
         x: 0
         y: 0
         width: 0
         height: 0
-      m_UserData: 0
+      m_UserData: 26144
       m_IsWaitingForDelay: 0
       m_IsRenaming: 0
-      m_OriginalEventType: 11
+      m_OriginalEventType: 0
       m_IsRenamingFilename: 1
       m_ClientGUIView: {fileID: 5}
     m_CreateAssetUtility:
@@ -413,7 +413,7 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
     m_NewAssetIndexInList: -1
-    m_ScrollPosition: {x: 0, y: 3.600006}
+    m_ScrollPosition: {x: 0, y: 0}
     m_GridSize: 16
   m_SkipHiddenPackages: 0
   m_DirectoriesAreaWidth: 198
@@ -489,9 +489,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: a8f8ffff
-      m_LastClickedID: -1880
-      m_ExpandedIDs: a8f8ffff2afbffff
+      m_SelectedIDs: 48230000
+      m_LastClickedID: 0
+      m_ExpandedIDs: 2afbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 


### PR DESCRIPTION
Garuim mechanic:
- garium now generates as currency
- garium is deducted when tower is upgraded
- garium is increased when tower is sold (~33% return)
- garium drops when enemy is dead
- garium will be set to 0 if it turns negative

Upgrade  System
- tower can upgrade based on current garium
- tower can be sold to give garium (~33%)
- tower range increases when upgraded (subject to change)
- tower targets the right target even after upgrade
- tower menu is fully interactable

Enemy
- enemy drops garium
- enemy has hp and decreases every time bullet hits enemy (subject to change based on Wood's code)

Others
- added Tag named "Projectile"

TO DO:
- make new enemy prefabs for diff enemy types
- add the tower build mechanic
   -> means that tower will be built in certain places (similar to kingdom rush)
- optimize code/code readability